### PR TITLE
Update Go to 1.15

### DIFF
--- a/.github/workflows/benchstat.yml
+++ b/.github/workflows/benchstat.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.15.x
       - name: Checkout
         uses: actions/checkout@v2
       - name: Benchmark
@@ -35,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.15.x
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.15.x
       - name: Setup Go ENV
         run: |
           echo "::set-env name=GOPATH::${{ github.workspace }}/go"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.13.x, 1.14.x]
+        go-version: [1.14.x, 1.15.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
           cp /tmp/golangci-lint/golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64/golangci-lint ${HOME}/golangci-lint
           rm -rf /tmp/golangci-lint.tar.gz /tmp/golangci-lint
         env:
-          GOLANGCILINT_VERSION: 1.30.0 # https://github.com/golangci/golangci-lint/releases
+          GOLANGCILINT_VERSION: 1.29.0 # https://github.com/golangci/golangci-lint/releases
       - name: Checkout
         uses: actions/checkout@v2
       - name: Format

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,7 +23,7 @@ jobs:
           cp /tmp/golangci-lint/golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64/golangci-lint ${HOME}/golangci-lint
           rm -rf /tmp/golangci-lint.tar.gz /tmp/golangci-lint
         env:
-          GOLANGCILINT_VERSION: 1.29.0 # https://github.com/golangci/golangci-lint/releases
+          GOLANGCILINT_VERSION: 1.30.0 # https://github.com/golangci/golangci-lint/releases
       - name: Checkout
         uses: actions/checkout@v2
       - name: Format


### PR DESCRIPTION
Not updating the go directive in [`go.mod`](https://github.com/github/go-fault/blob/main/go.mod#L3) because we're not using any new features in 1.15.