### PR TITLE
Add SetEnabled and SetParticipation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -124,7 +124,7 @@ to NewSlowInjector().
 Configuration
 
 Configuration for the fault package is done through options passed to NewFault and NewInjector. Once
-a Fault is created it's enabled state and participation percentage can be updated with SetEnabled()
+a Fault is created its enabled state and participation percentage can be updated with SetEnabled()
 and SetParticipation(). There is no other way to manage configuration for the package. It is up to
 the user of the fault package to manage how the options are generated. Common options are feature
 flags, environment variables, or code changes in deploys.

--- a/doc.go
+++ b/doc.go
@@ -123,10 +123,11 @@ to NewSlowInjector().
 
 Configuration
 
-All configuration for the fault package is done through options passed to NewFault and NewInjector.
-There is no other way to manage configuration for the package. It is up to the user of the fault
-package to manage how the options are generated. Common options are feature flags, environment
-variables, or code changes in deploys.
+Configuration for the fault package is done through options passed to NewFault and NewInjector. Once
+a Fault is created it's enabled state and participation percentage can be updated with SetEnabled()
+and SetParticipation(). There is no other way to manage configuration for the package. It is up to
+the user of the fault package to manage how the options are generated. Common options are feature
+flags, environment variables, or code changes in deploys.
 
 */
 package fault

--- a/fault.go
+++ b/fault.go
@@ -236,6 +236,16 @@ func (f *Fault) Handler(next http.Handler) http.Handler {
 	})
 }
 
+// SetEnabled updates the enabled state of the Fault.
+func (f *Fault) SetEnabled(o enabledOption) error {
+	return o.applyFault(f)
+}
+
+// SetParticipation updates the participation percentage of the Fault.
+func (f *Fault) SetParticipation(o participationOption) error {
+	return o.applyFault(f)
+}
+
 // checkAllowBlockLists checks the request against the provided allowlists and blocklists, returning
 // true if the request may proceed and false otherwise.
 func (f *Fault) checkAllowBlockLists(shouldEvaluate bool, r *http.Request) bool {

--- a/fault_test.go
+++ b/fault_test.go
@@ -300,6 +300,50 @@ func TestFaultHandler(t *testing.T) {
 	}
 }
 
+// TestFaultSetEnabled tests Fault.SetEnabled().
+func TestFaultSetEnabled(t *testing.T) {
+	t.Parallel()
+
+	f, err := NewFault(newTestInjector500s(),
+		WithEnabled(true),
+		WithParticipation(1.0),
+	)
+	assert.NoError(t, err)
+
+	rr := testRequest(t, f)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, http.StatusText(http.StatusInternalServerError), strings.TrimSpace(rr.Body.String()))
+
+	err = f.SetEnabled(false)
+	assert.NoError(t, err)
+
+	rr = testRequest(t, f)
+	assert.Equal(t, testHandlerCode, rr.Code)
+	assert.Equal(t, testHandlerBody, strings.TrimSpace(rr.Body.String()))
+}
+
+// TestFaultSetParticipation tests Fault.SetParticipation().
+func TestFaultSetParticipation(t *testing.T) {
+	t.Parallel()
+
+	f, err := NewFault(newTestInjector500s(),
+		WithEnabled(true),
+		WithParticipation(1.0),
+	)
+	assert.NoError(t, err)
+
+	rr := testRequest(t, f)
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+	assert.Equal(t, http.StatusText(http.StatusInternalServerError), strings.TrimSpace(rr.Body.String()))
+
+	err = f.SetParticipation(0.0)
+	assert.NoError(t, err)
+
+	rr = testRequest(t, f)
+	assert.Equal(t, testHandlerCode, rr.Code)
+	assert.Equal(t, testHandlerBody, strings.TrimSpace(rr.Body.String()))
+}
+
 // TestFaultPercentDo tests the internal Fault.participate().
 func TestFaultPercentDo(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Adds two new methods on Fault `SetEnabled` and `SetParticipation` that can be used to modify the fault after it is created.

closes https://github.com/github/go-fault/issues/12 https://github.com/github/go-fault/issues/13

cc @clarktlaugh