### PR TITLE
Update supported go versions

### DIFF
--- a/.github/workflows/benchstat.yml
+++ b/.github/workflows/benchstat.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
       - name: Checkout
         uses: actions/checkout@v2
       - name: Benchmark
@@ -35,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
       - name: Checkout
         uses: actions/checkout@v2
         with:
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.16.x
       - name: Install benchstat
         run: go get -u golang.org/x/perf/cmd/benchstat
       - name: Download Incoming

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.15.x, 1.16.x]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
@@ -23,7 +23,7 @@ jobs:
           cp /tmp/golangci-lint/golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64/golangci-lint ${HOME}/golangci-lint
           rm -rf /tmp/golangci-lint.tar.gz /tmp/golangci-lint
         env:
-          GOLANGCILINT_VERSION: 1.31.0 # https://github.com/golangci/golangci-lint/releases
+          GOLANGCILINT_VERSION: 1.37.0 # https://github.com/golangci/golangci-lint/releases
       - name: Checkout
         uses: actions/checkout@v2
       - name: Format

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/github/go-fault
 
-go 1.14
+go 1.15
 
 require github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
Go 1.16 was recently released. This project aims to support 1 version back from the most recent version.