### PR TITLE
Do not run code scanning on push (only pull requests)

### DIFF
--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -1,7 +1,6 @@
 name: Code Scanning
 
 on:
-  push:
   pull_request:
   schedule:
     - cron: 0 16 * * 2 # Every Tuesday at 16:00 UTC


### PR DESCRIPTION
Scans on dependabot branches will fail on the `push` event. It's fine to just run code scanning on PRs only.

> Workflows triggered by Dependabot on the "push" event run with read-only access. Uploading Code Scanning results requires write access. To use Code Scanning with Dependabot, please ensure you are using the "pull_request" event for this workflow and avoid triggering on the "push" event for Dependabot branches.
> LINK: https://github.com/github/go-fault/runs/5394470264?check_suite_focus=true