### PR TITLE
upgrade to go 1.20

### DIFF
--- a/.github/workflows/benchstat.yml
+++ b/.github/workflows/benchstat.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: stable
       - name: Checkout
         uses: actions/checkout@v3
       - name: Benchmark
@@ -35,7 +35,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: stable
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -57,7 +57,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19.x
+          go-version: stable
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest
       - name: Download Incoming

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -8,28 +8,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        go-version: [1.18.x, 1.19.x]
+        go-version: [oldstable, stable]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Install golangci-lint
-        run: |
-          wget -q https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCILINT_VERSION}/golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64.tar.gz -O /tmp/golangci-lint.tar.gz
-          mkdir /tmp/golangci-lint
-          tar -xzf /tmp/golangci-lint.tar.gz -C /tmp/golangci-lint
-          cp /tmp/golangci-lint/golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64/golangci-lint ${HOME}/golangci-lint
-          rm -rf /tmp/golangci-lint.tar.gz /tmp/golangci-lint
-        env:
-          GOLANGCILINT_VERSION: 1.48.0 # https://github.com/golangci/golangci-lint/releases
       - name: Checkout
         uses: actions/checkout@v3
       - name: Format
         run: test -z $(gofmt -l -w -s ./)
       - name: Lint
-        run: ${HOME}/golangci-lint run --out-format github-actions
+        uses: golangci/golangci-lint-action@v3.4.0
       - name: Test
         run: go test -v -race -cover -coverprofile=coverage.txt ./... | tee -a test-results.txt
       - name: Upload Test Results

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,6 @@
 linters:
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - dupl
@@ -34,18 +33,12 @@ linters:
     - prealloc
     - rowserrcheck
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
-  disable:
-    - interfacer # deprecated
-    - maligned # not worth savings
-    - wsl # too strict
 
 linters-settings:
   dupl:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/github/go-fault
 
-go 1.18
+go 1.19
 
 require github.com/stretchr/testify v1.8.1
 


### PR DESCRIPTION
- Upgrade to go 1.20
- Use golangci-lint github action over manual install
- Use `stable` and `oldstable` tags over explicit versions in actions
- Remove deprecated linters