### PR TITLE
Updates to prep for repo transfer

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,5 +1,0 @@
-# Security
-
-If you discover a security issue in this repo, please submit it through the [GitHub Security Bug Bounty](https://hackerone.com/github).
-
-Thanks for helping make GitHub safe for everyone.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 GitHub
+Copyright (c) 2020 Sean Lingren
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This removes the reference to GitHub's Bug Bounty in SECURITY.md
and updates the Copyright slug.

Relates to github/open-source-releases#337
